### PR TITLE
Defined xrange() for Python 3

### DIFF
--- a/evaluation/evaluate_kitti3dmot.py
+++ b/evaluation/evaluate_kitti3dmot.py
@@ -8,11 +8,16 @@ from munkres import Munkres
 from collections import defaultdict
 try:
     from ordereddict import OrderedDict # can be installed using pip
-except:
+except ImportError:
     from collections import OrderedDict # only included from python 2.7 on
 
 import mailpy
 from box_util import boxoverlap, box3doverlap
+
+try:
+    xrange
+except NameError:
+    xrange = range
 
 num_sample_pts = 11.0
 
@@ -527,7 +532,7 @@ class trackingEvaluation(object):
                     seq_trajectories[gg.track_id].append(-1)
                     seq_ignored[gg.track_id].append(False)
 
-                if len(g) is 0:
+                if len(g) == 0:
                     cost_matrix=[[]]
                 # associate
                 association_matrix = hm.compute(cost_matrix)


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.  This change ensures equivalent functionality in both Python 2 and Python 3.