### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/evaluation/evaluate_kitti3dmot.py
+++ b/evaluation/evaluate_kitti3dmot.py
@@ -527,7 +527,7 @@ class trackingEvaluation(object):
                     seq_trajectories[gg.track_id].append(-1)
                     seq_ignored[gg.track_id].append(False)
 
-                if len(g) is 0:
+                if len(g) == 0:
                     cost_matrix=[[]]
                 # associate
                 association_matrix = hm.compute(cost_matrix)


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8