### PR TITLE
Use 2D overlap for don't care areas instead of 3D

### DIFF
--- a/evaluation/evaluate_kitti3dmot.py
+++ b/evaluation/evaluate_kitti3dmot.py
@@ -585,8 +585,7 @@ class trackingEvaluation(object):
                         ignoredtrackers[tt.track_id] = 1
                         continue
                     for d in dc:
-                        # overlap = boxoverlap(tt,d,"a")
-                        overlap = box3doverlap(tt,d,"a")
+                        overlap = boxoverlap(tt,d,"a")
                         if overlap>0.5 and not tt.valid:
                             tt.ignored      = True
                             nignoredtracker+= 1


### PR DESCRIPTION
KITTI doesn't have ground truth 3D bounding boxes for don't care areas. Instead, they provide default values with zero overlap to any real bounding box. Because of that, we should compute the 2D overlap for don't care areas in every case.